### PR TITLE
Seprating logout functionailty from data functionality in Settings

### DIFF
--- a/OpenMRS-iOS/SettingsViewController.m
+++ b/OpenMRS-iOS/SettingsViewController.m
@@ -25,31 +25,23 @@
 }
 -(NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-    return 1;
+    return 2;
 }
 -(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 3;
+	if (section == 0)
+	{
+		return 2;
+	}
+	else
+	{
+		return 1;
+	}
 }
 -(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath.section == 0)
     {
-        if (indexPath.row == 2)
-        {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"clearCell"];
-            
-            if (!cell)
-            {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"clearCell"];
-            }
-            
-            cell.textLabel.textColor = [UIColor redColor];
-            cell.textLabel.textAlignment = NSTextAlignmentCenter;
-            cell.textLabel.text = @"Remove Offline Patients";
-            
-            return cell;
-        }
         if (indexPath.row == 1)
         {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"logoutCell"];
@@ -82,6 +74,23 @@
             return usernameCell;
         }
     }
+	if (indexPath.section == 1)
+	{
+		if (indexPath.row == 0) {
+			UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"clearCell"];
+
+			if (!cell)
+			{
+				cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"clearCell"];
+			}
+
+			cell.textLabel.textColor = [UIColor redColor];
+			cell.textLabel.textAlignment = NSTextAlignmentCenter;
+			cell.textLabel.text = @"Remove Offline Patients";
+
+			return cell;
+		}
+	}
     return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
 }
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Seprating the part about login information and logout
functions from removing the offline saved patients
as they are different and don't belong together.

I think it looks better that way.
![ios simulator screen shot mar 12 2015 7 19 12 am](https://cloud.githubusercontent.com/assets/3893067/6612651/e6bfb9fe-c888-11e4-8549-cbe24f339e9c.png)