### PR TITLE
Fixing migrations issues

### DIFF
--- a/OpenMRS-iOS/PatientViewController.m
+++ b/OpenMRS-iOS/PatientViewController.m
@@ -58,7 +58,12 @@
     self.navigationItem.title = self.patient.name;
     self.tabBarItem.title = [self.patient.name componentsSeparatedByString:@" "].firstObject;
     [self.tableView reloadData];
-    if (!_patient.hasDetailedInfo) {
+    /* This is a just checking a random detailed value that will 
+     * tell us if this is a detailed patient or not, because the old
+     * loading from coredata will return .hasdetailedinfo as nill
+     * and the app will be caught in an infintie loop.
+     */
+    if (!_patient.gender) {
         [self updateWithDetailedInfo];
     }
 }

--- a/OpenMRS-iOS/SyncingEngine.m
+++ b/OpenMRS-iOS/SyncingEngine.m
@@ -58,6 +58,7 @@
             dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
             [OpenMRSAPIManager getDetailedDataOnPatient:patient completion:^(NSError *error, MRSPatient *detailedPatient) {
                 if (!error) {
+                    patient = detailedPatient;
                     patient.upToDate = YES;
                     [patient saveToCoreData];
                 } else {


### PR DESCRIPTION
- Syncing engine wasn't assiging saving new detailed patients DUH!
- A hack to fix return a null value in -hasDetailedInfo- property
from patient entity in coredata

Signed-off-by: Yousef Hamza <jo.adam.93@gmail.com>